### PR TITLE
chore: scaffold data-structures, string, math, backtracking modules

### DIFF
--- a/src/backtracking/mod.rs
+++ b/src/backtracking/mod.rs
@@ -1,0 +1,1 @@
+//! Backtracking algorithms: N-queens, Sudoku, permutations.

--- a/src/data_structures/mod.rs
+++ b/src/data_structures/mod.rs
@@ -1,0 +1,1 @@
+//! Reusable data structures: union-find, Fenwick tree, segment tree, trie, etc.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,11 @@
 //! Each submodule groups related algorithms. Implementations are independent
 //! of one another and can be copied out individually.
 
+pub mod backtracking;
+pub mod data_structures;
 pub mod dynamic_programming;
 pub mod graph;
+pub mod math;
 pub mod searching;
 pub mod sorting;
+pub mod string;

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -1,0 +1,1 @@
+//! Number theory and elementary mathematics.

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -1,0 +1,1 @@
+//! String algorithms: substring search, suffix structures, Z-array, etc.


### PR DESCRIPTION
## Summary
Add empty module skeletons for the four upcoming algorithm categories that don't exist yet: `data_structures`, `string`, `math`, `backtracking`. Wires each into `src/lib.rs`. Future PRs land individual algorithms into these modules.

## Test plan
- [x] `cargo build` succeeds
- [x] No public API change to existing modules