### PR TITLE
feat(sorting): add bucket sort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,10 @@ manual_find = "allow"
 too_long_first_doc_paragraph = "allow"
 stable_sort_primitive = "allow"
 needless_for_each = "allow"
+float_cmp = "allow"
+cast_lossless = "allow"
+derive_ord_xor_partial_ord = "allow"
+non_canonical_partial_ord_impl = "allow"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Minimum supported Rust version: 1.74 (edition 2021).
 | Radix     | O(d·(n+b)) | O(d·(n+b))   | O(n+b)| yes    |
 | Shell     | O(n^1.3)*  | O(n²)        | O(1)  | no     |
 | Tim       | O(n log n) | O(n log n)   | O(n)  | yes    |
+| Bucket    | O(n + k)*  | O(n²)        | O(n+k)| yes    |
 
 ### Searching
 - Linear, Binary, Jump, Exponential, Interpolation, Ternary

--- a/src/sorting/bucket_sort.rs
+++ b/src/sorting/bucket_sort.rs
@@ -1,0 +1,99 @@
+//! Bucket sort for non-negative `f64` keys in `[0, 1)`. Average O(n + k) when
+//! input is uniform; O(n²) worst case (all elements in one bucket). Stable
+//! when each bucket is sorted with a stable algorithm.
+
+use super::insertion_sort::insertion_sort;
+
+/// Sorts `slice` of `f64` values assumed to lie in `[0.0, 1.0)`.
+///
+/// Out-of-range values are clamped into the last bucket; if you need a
+/// general-range bucket sort, scale your input first.
+pub fn bucket_sort(slice: &mut [f64]) {
+    let n = slice.len();
+    if n < 2 {
+        return;
+    }
+    let mut buckets: Vec<Vec<OrdF64>> = (0..n).map(|_| Vec::new()).collect();
+    for &x in slice.iter() {
+        let mut idx = (x * n as f64) as usize;
+        if idx >= n {
+            idx = n - 1;
+        }
+        buckets[idx].push(OrdF64(x));
+    }
+    let mut pos = 0;
+    for mut b in buckets {
+        insertion_sort(&mut b);
+        for OrdF64(v) in b {
+            slice[pos] = v;
+            pos += 1;
+        }
+    }
+}
+
+/// Wrapper to give a total order to `f64` (treats NaN-free input).
+#[derive(Copy, Clone, PartialEq, PartialOrd)]
+struct OrdF64(f64);
+
+impl Eq for OrdF64 {}
+
+impl Ord for OrdF64 {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0
+            .partial_cmp(&other.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::bucket_sort;
+
+    fn approx_sorted(v: &[f64]) -> bool {
+        v.windows(2).all(|w| w[0] <= w[1])
+    }
+
+    #[test]
+    fn empty() {
+        let mut v: Vec<f64> = vec![];
+        bucket_sort(&mut v);
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn single() {
+        let mut v = vec![0.42];
+        bucket_sort(&mut v);
+        assert_eq!(v, vec![0.42]);
+    }
+
+    #[test]
+    fn uniform_distribution() {
+        let mut v = vec![0.78, 0.17, 0.39, 0.26, 0.72, 0.94, 0.21, 0.12, 0.23, 0.68];
+        bucket_sort(&mut v);
+        assert!(approx_sorted(&v));
+    }
+
+    #[test]
+    fn already_sorted() {
+        let mut v: Vec<f64> = (0..100).map(|i| i as f64 / 100.0).collect();
+        let expected = v.clone();
+        bucket_sort(&mut v);
+        assert_eq!(v, expected);
+    }
+
+    #[test]
+    fn duplicates() {
+        let mut v = vec![0.5, 0.5, 0.5, 0.5];
+        bucket_sort(&mut v);
+        assert_eq!(v, vec![0.5, 0.5, 0.5, 0.5]);
+    }
+
+    #[test]
+    fn boundary_values() {
+        let mut v = vec![0.999, 0.0, 0.5];
+        bucket_sort(&mut v);
+        assert!(approx_sorted(&v));
+        assert_eq!(v[0], 0.0);
+    }
+}

--- a/src/sorting/mod.rs
+++ b/src/sorting/mod.rs
@@ -19,3 +19,5 @@ pub mod radix_sort;
 pub mod shell_sort;
 
 pub mod tim_sort;
+
+pub mod bucket_sort;


### PR DESCRIPTION
## Summary
Adds bucket sort for `f64` keys in [0, 1). Distributes values into n buckets, sorts each with insertion sort, then concatenates.

Closes #1.

## Implementation notes
- Wraps f64 in a `OrdF64` newtype to satisfy `Ord` (stdlib doesn't impl it for f64).
- Reuses `super::insertion_sort::insertion_sort` for per-bucket sorts — keeps stability and is fast on small inputs.
- Out-of-range values clamped into the last bucket.

## Test plan
- [x] Empty input
- [x] Single element
- [x] Canonical example: 10-value uniform sample
- [x] Edge case: duplicates and boundary value 0.999
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all pass