### PR TITLE
feat(sorting): add comb sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Minimum supported Rust version: 1.74 (edition 2021).
 | Tim       | O(n log n) | O(n log n)   | O(n)  | yes    |
 | Bucket    | O(n + k)*  | O(n²)        | O(n+k)| yes    |
 | Gnome     | O(n²)      | O(n²)        | O(1)  | yes    |
+| Comb      | ~O(n log n)| O(n²)        | O(1)  | no     |
 
 ### Searching
 - Linear, Binary, Jump, Exponential, Interpolation, Ternary

--- a/src/sorting/comb_sort.rs
+++ b/src/sorting/comb_sort.rs
@@ -1,0 +1,79 @@
+//! Comb sort. In-place, not stable, O(n²) worst, ~O(n log n) typical.
+//!
+//! Bubble-sort variant with a shrinking gap (Knuth shrink factor 1.3).
+//! Eliminates "turtles" — small values near the end that slow down bubble
+//! sort — by comparing distant elements first.
+
+const SHRINK: f64 = 1.3;
+
+/// Sorts `slice` in non-decreasing order using comb sort.
+pub fn comb_sort<T: Ord>(slice: &mut [T]) {
+    let n = slice.len();
+    if n < 2 {
+        return;
+    }
+    let mut gap = n;
+    let mut sorted = false;
+    while !sorted {
+        gap = ((gap as f64) / SHRINK) as usize;
+        if gap <= 1 {
+            gap = 1;
+            sorted = true;
+        }
+        for i in 0..(n - gap) {
+            if slice[i] > slice[i + gap] {
+                slice.swap(i, i + gap);
+                sorted = false;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::comb_sort;
+    use quickcheck_macros::quickcheck;
+
+    #[test]
+    fn empty() {
+        let mut v: Vec<i32> = vec![];
+        comb_sort(&mut v);
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn single() {
+        let mut v = vec![42];
+        comb_sort(&mut v);
+        assert_eq!(v, vec![42]);
+    }
+
+    #[test]
+    fn random() {
+        let mut v = vec![8, 4, 1, 56, 3, -44, 23, -6, 28, 0];
+        comb_sort(&mut v);
+        assert_eq!(v, vec![-44, -6, 0, 1, 3, 4, 8, 23, 28, 56]);
+    }
+
+    #[test]
+    fn reverse_eliminates_turtles() {
+        let mut v: Vec<i32> = (0..50).rev().collect();
+        comb_sort(&mut v);
+        assert_eq!(v, (0..50).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn all_equal() {
+        let mut v = vec![3; 20];
+        comb_sort(&mut v);
+        assert_eq!(v, vec![3; 20]);
+    }
+
+    #[quickcheck]
+    fn matches_std_sort(mut input: Vec<i32>) -> bool {
+        let mut expected = input.clone();
+        expected.sort();
+        comb_sort(&mut input);
+        input == expected
+    }
+}

--- a/src/sorting/mod.rs
+++ b/src/sorting/mod.rs
@@ -23,3 +23,5 @@ pub mod tim_sort;
 pub mod bucket_sort;
 
 pub mod gnome_sort;
+
+pub mod comb_sort;


### PR DESCRIPTION
## Summary
Adds comb sort: a bubble-sort variant with a shrinking gap (Knuth factor 1.3).

Closes #3.

## Implementation notes
- Gap starts at n, divided by 1.3 each pass; eliminates 'turtles' (small values stuck near the end of the array).
- Terminates when gap = 1 and a full pass produces no swaps.

## Test plan
- [x] Empty input
- [x] Single element
- [x] Canonical example: 10-element mixed slice
- [x] Edge case: reverse-sorted (worst case for plain bubble, where comb shines)
- [x] Edge case: all-equal values
- [x] quickcheck property test vs slice::sort
- [x] fmt / clippy / cargo test green