### PR TITLE
feat(searching): add Fibonacci search

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Minimum supported Rust version: 1.74 (edition 2021).
 | Pigeonhole| O(n + r)   | O(n + r)     | O(r)  | yes    |
 
 ### Searching
-- Linear, Binary, Jump, Exponential, Interpolation, Ternary
+- Linear, Binary, Jump, Exponential, Interpolation, Ternary, Fibonacci
 
 ### Graph
 - Breadth-first, Depth-first, Dijkstra, Bellman–Ford, Kruskal, Prim,

--- a/src/searching/fibonacci_search.rs
+++ b/src/searching/fibonacci_search.rs
@@ -1,0 +1,96 @@
+//! Fibonacci search on a sorted slice. O(log n) comparisons; each split is
+//! computed using only addition and subtraction (no division), historically
+//! useful when division is expensive (early hardware, magnetic-tape access).
+
+/// Returns the index of an element equal to `target` in the sorted `slice`,
+/// or `None`. The slice MUST be sorted in non-decreasing order.
+pub fn fibonacci_search<T: Ord>(slice: &[T], target: &T) -> Option<usize> {
+    let n = slice.len();
+    if n == 0 {
+        return None;
+    }
+    // Build the smallest Fibonacci number >= n.
+    let (mut fk_minus_2, mut fk_minus_1) = (0_usize, 1_usize);
+    let mut fk = fk_minus_1 + fk_minus_2;
+    while fk < n {
+        fk_minus_2 = fk_minus_1;
+        fk_minus_1 = fk;
+        fk = fk_minus_1 + fk_minus_2;
+    }
+    let mut offset: isize = -1;
+    while fk > 1 {
+        let i = (offset + fk_minus_2 as isize).min(n as isize - 1) as usize;
+        match slice[i].cmp(target) {
+            std::cmp::Ordering::Equal => return Some(i),
+            std::cmp::Ordering::Less => {
+                fk = fk_minus_1;
+                fk_minus_1 = fk_minus_2;
+                fk_minus_2 = fk - fk_minus_1;
+                offset = i as isize;
+            }
+            std::cmp::Ordering::Greater => {
+                fk = fk_minus_2;
+                fk_minus_1 -= fk_minus_2;
+                fk_minus_2 = fk - fk_minus_1;
+            }
+        }
+    }
+    if fk_minus_1 == 1 && (offset + 1) as usize <= n - 1 && &slice[(offset + 1) as usize] == target
+    {
+        return Some((offset + 1) as usize);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fibonacci_search;
+
+    #[test]
+    fn empty() {
+        let v: [i32; 0] = [];
+        assert_eq!(fibonacci_search(&v, &0), None);
+    }
+
+    #[test]
+    fn single_present() {
+        let v = [42];
+        assert_eq!(fibonacci_search(&v, &42), Some(0));
+    }
+
+    #[test]
+    fn single_absent() {
+        let v = [42];
+        assert_eq!(fibonacci_search(&v, &7), None);
+    }
+
+    #[test]
+    fn finds_each_element() {
+        let v: Vec<i32> = (1..=50).collect();
+        for (i, x) in v.iter().enumerate() {
+            assert_eq!(fibonacci_search(&v, x), Some(i), "value {x}");
+        }
+    }
+
+    #[test]
+    fn missing_in_middle() {
+        let v = [1, 3, 5, 7, 9, 11, 13];
+        assert_eq!(fibonacci_search(&v, &4), None);
+        assert_eq!(fibonacci_search(&v, &14), None);
+    }
+
+    #[test]
+    fn boundary_values() {
+        let v: Vec<i32> = (0..1024).collect();
+        assert_eq!(fibonacci_search(&v, &0), Some(0));
+        assert_eq!(fibonacci_search(&v, &1023), Some(1023));
+    }
+
+    #[test]
+    fn duplicates_returns_some_match() {
+        let v = vec![1, 2, 2, 2, 3];
+        let result = fibonacci_search(&v, &2);
+        assert!(result.is_some());
+        assert_eq!(v[result.unwrap()], 2);
+    }
+}

--- a/src/searching/mod.rs
+++ b/src/searching/mod.rs
@@ -11,3 +11,5 @@ pub mod exponential_search;
 pub mod interpolation_search;
 
 pub mod ternary_search;
+
+pub mod fibonacci_search;


### PR DESCRIPTION
## Summary
Adds Fibonacci search: a sorted-array search that splits intervals using Fibonacci numbers, requiring only addition/subtraction (no division) per step.

Closes #5.

## Implementation notes
- O(log n) comparisons.
- Useful historically when division was expensive; today mainly a teaching exercise.

## Test plan
- [x] Empty input
- [x] Single element (present and absent)
- [x] Canonical example: every value in [1, 50]
- [x] Edge case: missing values in the middle and beyond range
- [x] Edge case: duplicates (returns some valid match)
- [x] Edge case: first and last element of a 1024-element slice
- [x] fmt / clippy / cargo test green