### PR TITLE
fix(searching): silence int_plus_one in fibonacci_search bound check

### DIFF
--- a/src/searching/fibonacci_search.rs
+++ b/src/searching/fibonacci_search.rs
@@ -35,8 +35,7 @@ pub fn fibonacci_search<T: Ord>(slice: &[T], target: &T) -> Option<usize> {
             }
         }
     }
-    if fk_minus_1 == 1 && (offset + 1) as usize <= n - 1 && &slice[(offset + 1) as usize] == target
-    {
+    if fk_minus_1 == 1 && ((offset + 1) as usize) < n && &slice[(offset + 1) as usize] == target {
         return Some((offset + 1) as usize);
     }
     None


### PR DESCRIPTION
## Summary
Replaces `x <= n - 1` with `(x) < n` in the final-step bound check (silences clippy's `int_plus_one` lint).

## Test plan
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test green