### PR TITLE
feat(data-structures): add union-find module

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Minimum supported Rust version: 1.74 (edition 2021).
   Topological sort, Floyd–Warshall, A* search, Tarjan SCC, Kosaraju SCC,
   Edmonds–Karp max-flow, bridges & articulation points
 
+### Data Structures
+- Union-find (disjoint set) — union by rank + path compression
+
 ### Dynamic Programming
 - Fibonacci (memoised), 0/1 Knapsack, Longest Common Subsequence,
   Longest Increasing Subsequence, Edit Distance, Coin Change,

--- a/src/data_structures/mod.rs
+++ b/src/data_structures/mod.rs
@@ -1,1 +1,3 @@
 //! Reusable data structures: union-find, Fenwick tree, segment tree, trie, etc.
+
+pub mod union_find;

--- a/src/data_structures/union_find.rs
+++ b/src/data_structures/union_find.rs
@@ -1,0 +1,121 @@
+//! Union–find / disjoint-set data structure with union by rank and path
+//! compression. Each operation runs in amortised inverse-Ackermann time
+//! (effectively constant for any reasonable input size).
+
+/// Disjoint set forest over `n` elements `0..n`.
+pub struct UnionFind {
+    parent: Vec<usize>,
+    rank: Vec<u8>,
+    components: usize,
+}
+
+impl UnionFind {
+    /// Creates a new disjoint-set forest with `n` singleton components.
+    pub fn new(n: usize) -> Self {
+        Self {
+            parent: (0..n).collect(),
+            rank: vec![0; n],
+            components: n,
+        }
+    }
+
+    /// Returns the canonical representative of `x`'s component, applying
+    /// path compression along the way.
+    pub fn find(&mut self, x: usize) -> usize {
+        if self.parent[x] != x {
+            let root = self.find(self.parent[x]);
+            self.parent[x] = root;
+        }
+        self.parent[x]
+    }
+
+    /// Unions the components containing `a` and `b`. Returns `true` if a
+    /// merge occurred, `false` if they were already in the same set.
+    pub fn union(&mut self, a: usize, b: usize) -> bool {
+        let ra = self.find(a);
+        let rb = self.find(b);
+        if ra == rb {
+            return false;
+        }
+        match self.rank[ra].cmp(&self.rank[rb]) {
+            std::cmp::Ordering::Less => self.parent[ra] = rb,
+            std::cmp::Ordering::Greater => self.parent[rb] = ra,
+            std::cmp::Ordering::Equal => {
+                self.parent[rb] = ra;
+                self.rank[ra] += 1;
+            }
+        }
+        self.components -= 1;
+        true
+    }
+
+    /// Returns `true` if `a` and `b` are in the same component.
+    pub fn connected(&mut self, a: usize, b: usize) -> bool {
+        self.find(a) == self.find(b)
+    }
+
+    /// Number of disjoint components.
+    pub const fn component_count(&self) -> usize {
+        self.components
+    }
+
+    /// Total number of elements.
+    pub const fn len(&self) -> usize {
+        self.parent.len()
+    }
+
+    /// True if there are no elements.
+    pub const fn is_empty(&self) -> bool {
+        self.parent.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UnionFind;
+
+    #[test]
+    fn empty() {
+        let dsu = UnionFind::new(0);
+        assert!(dsu.is_empty());
+        assert_eq!(dsu.component_count(), 0);
+    }
+
+    #[test]
+    fn singletons() {
+        let dsu = UnionFind::new(5);
+        assert_eq!(dsu.component_count(), 5);
+        assert_eq!(dsu.len(), 5);
+    }
+
+    #[test]
+    fn union_and_find() {
+        let mut dsu = UnionFind::new(6);
+        assert!(dsu.union(0, 1));
+        assert!(dsu.union(2, 3));
+        assert!(dsu.union(1, 2));
+        assert!(dsu.connected(0, 3));
+        assert!(!dsu.connected(0, 4));
+        assert_eq!(dsu.component_count(), 3); // {0,1,2,3}, {4}, {5}
+    }
+
+    #[test]
+    fn duplicate_union_returns_false() {
+        let mut dsu = UnionFind::new(3);
+        assert!(dsu.union(0, 1));
+        assert!(!dsu.union(1, 0));
+        assert_eq!(dsu.component_count(), 2);
+    }
+
+    #[test]
+    fn path_compression_does_not_corrupt() {
+        let mut dsu = UnionFind::new(8);
+        for i in 1..8 {
+            dsu.union(i - 1, i);
+        }
+        for i in 0..8 {
+            assert_eq!(dsu.find(i), dsu.find(0));
+        }
+        assert_eq!(dsu.component_count(), 1);
+    }
+}

--- a/src/graph/kruskal.rs
+++ b/src/graph/kruskal.rs
@@ -1,5 +1,7 @@
-//! Kruskal's minimum spanning tree using a union-find disjoint-set structure.
-//! O(E log E).
+//! Kruskal's minimum spanning tree using the shared union-find data
+//! structure. O(E log E).
+
+use crate::data_structures::union_find::UnionFind;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Edge {
@@ -8,50 +10,13 @@ pub struct Edge {
     pub weight: i64,
 }
 
-struct DisjointSet {
-    parent: Vec<usize>,
-    rank: Vec<u8>,
-}
-
-impl DisjointSet {
-    fn new(n: usize) -> Self {
-        Self {
-            parent: (0..n).collect(),
-            rank: vec![0; n],
-        }
-    }
-    fn find(&mut self, x: usize) -> usize {
-        if self.parent[x] != x {
-            let root = self.find(self.parent[x]);
-            self.parent[x] = root;
-        }
-        self.parent[x]
-    }
-    fn union(&mut self, a: usize, b: usize) -> bool {
-        let ra = self.find(a);
-        let rb = self.find(b);
-        if ra == rb {
-            return false;
-        }
-        match self.rank[ra].cmp(&self.rank[rb]) {
-            std::cmp::Ordering::Less => self.parent[ra] = rb,
-            std::cmp::Ordering::Greater => self.parent[rb] = ra,
-            std::cmp::Ordering::Equal => {
-                self.parent[rb] = ra;
-                self.rank[ra] += 1;
-            }
-        }
-        true
-    }
-}
-
 /// Returns the edges of an MST and its total weight. If the graph is
 /// disconnected the result is a minimum spanning forest.
 pub fn kruskal(num_nodes: usize, edges: &[Edge]) -> (Vec<Edge>, i64) {
     let mut sorted: Vec<Edge> = edges.to_vec();
     sorted.sort_by_key(|e| e.weight);
 
-    let mut dsu = DisjointSet::new(num_nodes);
+    let mut dsu = UnionFind::new(num_nodes);
     let mut tree = Vec::with_capacity(num_nodes.saturating_sub(1));
     let mut total: i64 = 0;
     for e in sorted {


### PR DESCRIPTION
## Summary
Promotes the union-find data structure (previously private inside `graph::kruskal`) to its own `data_structures::union_find` module with a public API. Refactors `kruskal.rs` to depend on it.

Closes #12.

## Implementation notes
- Union by rank + path compression — amortised O(α(n)) per operation.
- Public API: `new`, `find`, `union`, `connected`, `component_count`, `len`, `is_empty`.
- Kruskal now imports `UnionFind` instead of carrying its own copy.

## Test plan
- [x] Empty / singletons
- [x] Union + find on a 6-element forest
- [x] Duplicate union returns false
- [x] Path compression after chain-unions
- [x] Existing kruskal tests still pass
- [x] fmt / clippy / cargo test green