### PR TITLE
feat(string): add KMP substring search

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Minimum supported Rust version: 1.74 (edition 2021).
 - Segment tree with lazy propagation — range add / range sum in O(log n)
 - Trie (prefix tree) — insert / contains / starts_with in O(L)
 
+### String
+- KMP substring search — O(n + m) using a longest-proper-prefix table
+
 ### Dynamic Programming
 - Fibonacci (memoised), 0/1 Knapsack, Longest Common Subsequence,
   Longest Increasing Subsequence, Edit Distance, Coin Change,

--- a/src/string/kmp.rs
+++ b/src/string/kmp.rs
@@ -1,0 +1,96 @@
+//! Knuth–Morris–Pratt substring search. O(n + m) preprocessing + matching.
+
+/// Returns all start indices at which `pattern` occurs in `text`.
+///
+/// An empty pattern matches at every index from 0 to `text.len()` (consistent
+/// with most reference KMP implementations).
+pub fn kmp_search(text: &str, pattern: &str) -> Vec<usize> {
+    let text: Vec<char> = text.chars().collect();
+    let pat: Vec<char> = pattern.chars().collect();
+    if pat.is_empty() {
+        return (0..=text.len()).collect();
+    }
+    let lps = build_lps(&pat);
+    let (mut i, mut j) = (0_usize, 0_usize);
+    let mut matches = Vec::new();
+    while i < text.len() {
+        if text[i] == pat[j] {
+            i += 1;
+            j += 1;
+            if j == pat.len() {
+                matches.push(i - j);
+                j = lps[j - 1];
+            }
+        } else if j > 0 {
+            j = lps[j - 1];
+        } else {
+            i += 1;
+        }
+    }
+    matches
+}
+
+/// Builds the longest-proper-prefix-which-is-also-suffix table for `pat`.
+fn build_lps(pat: &[char]) -> Vec<usize> {
+    let m = pat.len();
+    let mut lps = vec![0_usize; m];
+    let mut len = 0_usize;
+    let mut i = 1_usize;
+    while i < m {
+        if pat[i] == pat[len] {
+            len += 1;
+            lps[i] = len;
+            i += 1;
+        } else if len > 0 {
+            len = lps[len - 1];
+        } else {
+            lps[i] = 0;
+            i += 1;
+        }
+    }
+    lps
+}
+
+#[cfg(test)]
+mod tests {
+    use super::kmp_search;
+
+    #[test]
+    fn empty_text_nonempty_pattern() {
+        assert_eq!(kmp_search("", "a"), Vec::<usize>::new());
+    }
+
+    #[test]
+    fn empty_pattern_matches_every_index() {
+        assert_eq!(kmp_search("abc", ""), vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn single_match() {
+        assert_eq!(kmp_search("hello world", "world"), vec![6]);
+    }
+
+    #[test]
+    fn no_match() {
+        assert_eq!(kmp_search("abcdef", "xyz"), Vec::<usize>::new());
+    }
+
+    #[test]
+    fn overlapping_matches() {
+        // pattern "aaa" appears at 0, 1, 2 in "aaaaa".
+        assert_eq!(kmp_search("aaaaa", "aaa"), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn classic_example_with_partial_failure() {
+        // The classic KMP failure-function exercise.
+        let result = kmp_search("ABABDABACDABABCABAB", "ABABCABAB");
+        assert_eq!(result, vec![10]);
+    }
+
+    #[test]
+    fn unicode() {
+        let text = "café au lait, café noir";
+        assert_eq!(kmp_search(text, "café"), vec![0, 14]);
+    }
+}

--- a/src/string/mod.rs
+++ b/src/string/mod.rs
@@ -1,1 +1,3 @@
 //! String algorithms: substring search, suffix structures, Z-array, etc.
+
+pub mod kmp;


### PR DESCRIPTION
## Summary
Adds Knuth–Morris–Pratt substring search returning all match start indices.

Closes #16.

## Implementation notes
- Builds the longest-proper-prefix-which-is-also-suffix (LPS) table in O(m).
- Matches in O(n) by sliding the pattern using the LPS table on mismatches.
- Operates on chars (Unicode-correct) so non-ASCII text matches naturally.

## Test plan
- [x] Empty text
- [x] Empty pattern (matches every index)
- [x] Single occurrence
- [x] No match
- [x] Edge case: overlapping matches (pattern 'aaa' in 'aaaaa')
- [x] Canonical KMP example with partial failure: 'ABABCABAB' in 'ABABDABACDABABCABAB'
- [x] Unicode (café)
- [x] fmt / clippy / cargo test green