### PR TITLE
ci(coverage): add cargo-llvm-cov workflow + codecov badge

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,40 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  coverage:
+    name: cargo-llvm-cov
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate coverage (lcov)
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload artifact (always)
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: lcov.info
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Rust-Algorithms
 
+[![CI](https://github.com/0xDevNinja/Rust-Algorithms/actions/workflows/ci.yml/badge.svg)](https://github.com/0xDevNinja/Rust-Algorithms/actions/workflows/ci.yml)
+[![Coverage](https://github.com/0xDevNinja/Rust-Algorithms/actions/workflows/coverage.yml/badge.svg)](https://github.com/0xDevNinja/Rust-Algorithms/actions/workflows/coverage.yml)
+[![codecov](https://codecov.io/gh/0xDevNinja/Rust-Algorithms/branch/main/graph/badge.svg)](https://codecov.io/gh/0xDevNinja/Rust-Algorithms)
+
 Classical algorithms implemented in idiomatic Rust, each paired with a thorough
 test suite. The goal of this repository is twofold:
 


### PR DESCRIPTION
## Summary
Adds a coverage workflow (`.github/workflows/coverage.yml`) that runs `cargo llvm-cov` on every push to `main` and every PR, exports lcov, and uploads the report to Codecov (when `CODECOV_TOKEN` secret is configured) and to a workflow artifact.

Adds CI / Coverage / Codecov badges to the README header.

Closes #27.

## Implementation notes
- Uses `taiki-e/install-action@cargo-llvm-cov` for the cargo-llvm-cov binary.
- `fail_ci_if_error: false` so the absence of a CODECOV_TOKEN doesn't block PRs from external contributors.
- Always uploads the lcov file as an artifact regardless of token availability.

## Test plan
- [x] YAML validates locally
- [x] No source code change; existing tests still green
- [x] README badges render against the workflow file names