### PR TITLE
fix(dp): sort by end in weighted-interval brute force

### DIFF
--- a/src/dynamic_programming/weighted_interval_scheduling.rs
+++ b/src/dynamic_programming/weighted_interval_scheduling.rs
@@ -102,7 +102,7 @@ mod tests {
                 .filter(|i| mask & (1 << i) != 0)
                 .map(|i| intervals[i])
                 .collect();
-            picked.sort_by_key(|iv| iv.0);
+            picked.sort_by_key(|iv| (iv.1, iv.0));
             let ok = picked.windows(2).all(|w| w[0].1 <= w[1].0);
             if ok {
                 let total: i64 = picked.iter().map(|iv| iv.2).sum();
@@ -267,8 +267,8 @@ mod tests {
         if sum != got {
             return false;
         }
-        let mut by_start: Vec<(i64, i64, i64)> = picked.iter().map(|&i| ivs[i]).collect();
-        by_start.sort_by_key(|iv| iv.0);
-        by_start.windows(2).all(|w| w[0].1 <= w[1].0)
+        let mut by_end: Vec<(i64, i64, i64)> = picked.iter().map(|&i| ivs[i]).collect();
+        by_end.sort_by_key(|iv| (iv.1, iv.0));
+        by_end.windows(2).all(|w| w[0].1 <= w[1].0)
     }
 }


### PR DESCRIPTION
## Summary
- Quickcheck `matches_brute_force` flaked when two intervals share a start coordinate but differ on end (e.g. `[(0,1,1), (0,0,1)]`): the brute-force sorted by start, so its pairwise compatibility check used a different order than the DP's by-end ordering and produced spurious mismatches.
- Switch the brute-force (and the in-test selection validator) to sort by `(end, start)` so both branches agree on the canonical ordering and the compatibility rule `a.end <= b.start`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib weighted_interval`
- [x] CI green (rustfmt, clippy, cargo-llvm-cov, test on ubuntu/macos/windows)