### PR TITLE
fix(data-structures): correct interval tree property test for duplicate intervals

### DIFF
--- a/src/data_structures/interval_tree.rs
+++ b/src/data_structures/interval_tree.rs
@@ -595,11 +595,24 @@ mod tests {
                 }
                 Op::Remove(lo, hi) => {
                     let tree_val = tree.remove_first_match(lo, hi);
-                    // Find and remove the first matching entry from the reference.
-                    let pos = store.iter().position(|((l, h), _)| *l == lo && *h == hi);
-                    let ref_val = pos.map(|i| store.remove(i).1);
-                    if tree_val != ref_val {
-                        return TestResult::failed();
+                    // Among duplicates the tree may return any matching entry,
+                    // so verify presence/absence and drop a reference entry
+                    // whose value matches what the tree returned.
+                    match tree_val {
+                        Some(v) => {
+                            let pos = store
+                                .iter()
+                                .position(|((l, h), val)| *l == lo && *h == hi && *val == v);
+                            let Some(i) = pos else {
+                                return TestResult::failed();
+                            };
+                            store.remove(i);
+                        }
+                        None => {
+                            if store.iter().any(|((l, h), _)| *l == lo && *h == hi) {
+                                return TestResult::failed();
+                            }
+                        }
                     }
                 }
                 Op::QueryOverlap(qlo, qhi) => {


### PR DESCRIPTION
## Summary
- Property test `prop_tree_matches_brute_force` compared `tree.remove_first_match` to "first by insertion order" in the reference store; when multiple intervals share the same `(low, high)`, the treap's "first match" can be a different node, producing flaky Windows-CI failures.
- Fix: compare presence/absence and drop the reference entry whose value matches what the tree returned, treating duplicates as a multiset.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib data_structures::interval_tree`