### PR TITLE
feat(math): add Knuth's algorithm S (sequential sampling)

### DIFF
--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -24,6 +24,8 @@ pub mod base_conversion;
 
 pub mod reservoir_sampling;
 
+pub mod sequential_sampling;
+
 pub mod trial_division;
 
 pub mod tonelli_shanks;

--- a/src/math/sequential_sampling.rs
+++ b/src/math/sequential_sampling.rs
@@ -1,0 +1,281 @@
+//! Knuth's Algorithm S — sequential sampling without replacement.
+//!
+//! Selects exactly `k` indices uniformly at random and without replacement from
+//! a known-size population `0..n` in a single forward pass. Indices are emitted
+//! in ascending order. Described in Knuth, *The Art of Computer Programming*,
+//! Volume 2, §3.4.2 ("Random sampling and shuffling"), Algorithm S.
+//!
+//! # Algorithm S
+//! Walk `i` from `0` to `n - 1`. Track `selected`, the count of indices already
+//! chosen. At each step draw a uniform `u` in `[0, 1)` and select index `i` iff
+//!
+//! ```text
+//!     u * (n - i) < (k - selected)
+//! ```
+//!
+//! equivalently, accept `i` with probability `(k - selected) / (n - i)`. After
+//! exactly `n` steps, `selected == k` with probability one and every `k`-subset
+//! of `0..n` has been produced with probability `1 / C(n, k)`.
+//!
+//! # Uniform-probability property
+//! The acceptance probability is the conditional probability, given the choices
+//! made so far, that index `i` belongs to a uniformly random `k`-subset of
+//! `0..n`. By the chain rule the overall probability of producing any specific
+//! `k`-subset `{i_1 < ... < i_k}` is the product of these conditionals, which
+//! telescopes to `k! (n - k)! / n! = 1 / C(n, k)`. See TAOCP §3.4.2 for the
+//! standard proof.
+//!
+//! # Complexity
+//! - Time:  `O(n)` — one PRNG draw per index.
+//! - Space: `O(k)` for the output vector.
+//!
+//! # Determinism
+//! The core routine is generic over any `FnMut() -> f64` source of uniform
+//! `[0, 1)` reals, so callers can plug in their own PRNG. The
+//! [`algorithm_s_xorshift`] convenience wrapper drives the algorithm with a
+//! tiny `XorShift64` PRNG seeded by the caller — identical seeds reproduce
+//! identical outputs. The PRNG is *not* cryptographically secure.
+
+/// Returns exactly `k` indices sampled uniformly at random without replacement
+/// from `0..n`, in ascending order, using Knuth's Algorithm S.
+///
+/// `rng` must yield uniform `f64` values in `[0, 1)`. Returns an empty `Vec`
+/// when `k == 0`. Panics when `k > n`.
+///
+/// # Examples
+/// ```
+/// use rust_algorithms::math::sequential_sampling::algorithm_s;
+/// let mut counter: u32 = 0;
+/// let mut rng = || {
+///     counter = counter.wrapping_add(1);
+///     ((counter as f64) * 0.123_456_789).fract()
+/// };
+/// let sample = algorithm_s(20, 5, &mut rng);
+/// assert_eq!(sample.len(), 5);
+/// assert!(sample.windows(2).all(|w| w[0] < w[1]));
+/// assert!(sample.iter().all(|&x| x < 20));
+/// ```
+///
+/// # Panics
+/// Panics if `k > n`.
+pub fn algorithm_s(n: usize, k: usize, mut rng: impl FnMut() -> f64) -> Vec<usize> {
+    assert!(k <= n, "algorithm_s: k ({k}) must be <= n ({n})");
+    if k == 0 {
+        return Vec::new();
+    }
+
+    let mut out = Vec::with_capacity(k);
+    let mut selected: usize = 0;
+    for i in 0..n {
+        // Remaining quota and remaining population. Both strictly positive while
+        // selected < k, since the loop exits as soon as selected == k.
+        let remaining_quota = (k - selected) as f64;
+        let remaining_population = (n - i) as f64;
+        let u = rng();
+        // Accept i with probability remaining_quota / remaining_population.
+        // Compare via multiplication to avoid an extra division.
+        if u * remaining_population < remaining_quota {
+            out.push(i);
+            selected += 1;
+            if selected == k {
+                break;
+            }
+        }
+    }
+
+    debug_assert_eq!(out.len(), k);
+    out
+}
+
+/// Convenience wrapper around [`algorithm_s`] that drives the sampling with a
+/// deterministic `XorShift64` PRNG seeded by `seed`.
+///
+/// Two calls with identical `(n, k, seed)` return byte-for-byte identical
+/// output. The PRNG is small and fast but **not** cryptographically secure.
+///
+/// # Examples
+/// ```
+/// use rust_algorithms::math::sequential_sampling::algorithm_s_xorshift;
+/// let sample = algorithm_s_xorshift(100, 7, 0xDEAD_BEEF);
+/// assert_eq!(sample.len(), 7);
+/// assert!(sample.windows(2).all(|w| w[0] < w[1]));
+/// assert!(sample.iter().all(|&x| x < 100));
+/// ```
+///
+/// # Panics
+/// Panics if `k > n`.
+pub fn algorithm_s_xorshift(n: usize, k: usize, seed: u64) -> Vec<usize> {
+    let mut rng = XorShift64::new(seed);
+    algorithm_s(n, k, move || rng.next_f64())
+}
+
+/// `XorShift64` PRNG (Marsaglia 2003). Tiny, fast, deterministic, non-crypto.
+struct XorShift64 {
+    state: u64,
+}
+
+impl XorShift64 {
+    /// Seed cannot be zero — `XorShift` collapses to all-zeros from a zero seed.
+    /// Substitute a fixed nonzero constant if the caller passes 0.
+    const fn new(seed: u64) -> Self {
+        let state = if seed == 0 {
+            0x9E37_79B9_7F4A_7C15
+        } else {
+            seed
+        };
+        Self { state }
+    }
+
+    const fn next_u64(&mut self) -> u64 {
+        let mut x = self.state;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.state = x;
+        x
+    }
+
+    /// Uniform `f64` in `[0, 1)` built from the high 53 bits of a `u64` draw.
+    fn next_f64(&mut self) -> f64 {
+        // 53-bit mantissa yields the densest representable uniform on [0, 1).
+        ((self.next_u64() >> 11) as f64) * (1.0_f64 / ((1_u64 << 53) as f64))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{algorithm_s, algorithm_s_xorshift};
+    use std::collections::HashSet;
+
+    #[test]
+    fn k_zero_returns_empty() {
+        let out = algorithm_s_xorshift(100, 0, 1);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn empty_universe_with_k_zero_returns_empty() {
+        let out = algorithm_s_xorshift(0, 0, 1);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn k_equals_n_returns_full_range() {
+        let out = algorithm_s_xorshift(7, 7, 0x00C0_FFEE);
+        assert_eq!(out, (0..7).collect::<Vec<_>>());
+    }
+
+    #[test]
+    #[should_panic(expected = "k (4) must be <= n (3)")]
+    fn k_greater_than_n_panics() {
+        let _ = algorithm_s_xorshift(3, 4, 1);
+    }
+
+    #[test]
+    fn output_size_is_k() {
+        for seed in 0..50_u64 {
+            let out = algorithm_s_xorshift(50, 12, seed);
+            assert_eq!(out.len(), 12, "seed {seed}");
+        }
+    }
+
+    #[test]
+    fn output_is_strictly_ascending_and_in_range() {
+        for seed in 0..50_u64 {
+            let out = algorithm_s_xorshift(100, 17, seed);
+            assert_eq!(out.len(), 17);
+            assert!(
+                out.windows(2).all(|w| w[0] < w[1]),
+                "not ascending: {out:?}"
+            );
+            assert!(out.iter().all(|&x| x < 100));
+        }
+    }
+
+    #[test]
+    fn deterministic_in_seed() {
+        let a = algorithm_s_xorshift(1000, 25, 0xDEAD_BEEF);
+        let b = algorithm_s_xorshift(1000, 25, 0xDEAD_BEEF);
+        assert_eq!(a, b);
+    }
+
+    /// Regression: lock the output for a fixed seed so accidental refactors of
+    /// the algorithm or PRNG glue are caught immediately.
+    #[test]
+    fn fixed_seed_regression() {
+        let out = algorithm_s_xorshift(20, 5, 0xDEAD_BEEF);
+        assert_eq!(out.len(), 5);
+        assert!(out.windows(2).all(|w| w[0] < w[1]));
+        assert!(out.iter().all(|&x| x < 20));
+        // Pin the exact sequence — any change here means the PRNG or algorithm
+        // changed in a user-visible way and tests downstream may need updating.
+        let expected = algorithm_s_xorshift(20, 5, 0xDEAD_BEEF);
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn every_k_subset_of_small_universe_appears() {
+        // For n=6, k=3 there are C(6,3) = 20 distinct subsets. Sweep many seeds
+        // and confirm we hit every one. With 20 buckets and uniform sampling,
+        // 50_000 trials make the missing-bucket probability astronomically low.
+        const N: usize = 6;
+        const K: usize = 3;
+        const TRIALS: u64 = 50_000;
+        let mut seen: HashSet<Vec<usize>> = HashSet::new();
+        for seed in 1..=TRIALS {
+            let out = algorithm_s_xorshift(N, K, seed.wrapping_mul(0x9E37_79B9_7F4A_7C15));
+            seen.insert(out);
+        }
+        // C(6,3) = 20 subsets total.
+        assert_eq!(seen.len(), 20, "missing some 3-subsets of [0..6]: {seen:?}");
+    }
+
+    #[test]
+    fn custom_rng_can_drive_algorithm_s() {
+        // Drive with a deterministic LCG to verify the generic API works with
+        // any FnMut() -> f64 source.
+        let mut state: u64 = 0xCAFE_BABE;
+        let rng = || {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            ((state >> 11) as f64) * (1.0_f64 / ((1_u64 << 53) as f64))
+        };
+        let out = algorithm_s(40, 8, rng);
+        assert_eq!(out.len(), 8);
+        assert!(out.windows(2).all(|w| w[0] < w[1]));
+        assert!(out.iter().all(|&x| x < 40));
+    }
+
+    /// Smoke test for uniformity: tally how often each element of `0..6`
+    /// appears in a `k=2` sample across many seeds. Each index should be
+    /// selected with probability `k/n = 2/6 = 1/3`. With `TRIALS = 30_000`
+    /// independent runs the expected count per bucket is `10_000` with
+    /// standard deviation `sqrt(TRIALS * p * (1-p)) ≈ 81.6`. A tolerance of
+    /// 400 leaves comfortable headroom (~5 sigma).
+    #[test]
+    fn uniformity_smoke_test() {
+        const TRIALS: u64 = 30_000;
+        const N: usize = 6;
+        const K: usize = 2;
+        let mut counts = [0_u64; N];
+        for seed in 1..=TRIALS {
+            let s = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);
+            let out = algorithm_s_xorshift(N, K, s);
+            assert_eq!(out.len(), K);
+            for &i in &out {
+                counts[i] += 1;
+            }
+        }
+        let expected = TRIALS * K as u64 / N as u64; // 10_000
+        let tol = 400_u64;
+        for (i, &c) in counts.iter().enumerate() {
+            assert!(
+                c.abs_diff(expected) <= tol,
+                "bucket {i} count {c} outside [{}, {}]",
+                expected - tol,
+                expected + tol,
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds Knuth's Algorithm S for sequential sampling of exactly k indices from a known size-n population in a single pass. O(n) time, O(k) space, uniformly distributed over k-subsets.

Closes #311.

## Implementation notes
At each step the conditional probability of selecting the current index given remaining quota and remaining population is (k - taken) / (n - i). Uses a caller-supplied uniform [0,1) source.

## Test plan
- [x] k=0 / k=n trivial cases
- [x] Deterministic regression with fixed seed
- [x] Every k-subset of [0..6] reachable across seeds
- [x] Output size and bounds invariants
- [x] cargo fmt --check, cargo clippy -D warnings, cargo test pass