### PR TITLE
feat(dp): add decode-ways DP count

### DIFF
--- a/src/dynamic_programming/decode_ways.rs
+++ b/src/dynamic_programming/decode_ways.rs
@@ -1,0 +1,110 @@
+//! Decode ways: count the number of ways to decode a digit string where the
+//! mapping is `1 = A`, `2 = B`, ..., `26 = Z`. Empty string decodes one way
+//! (the empty decoding); any string starting with `'0'` decodes zero ways.
+//!
+//! Recurrence (with `dp[0] = 1`):
+//!   `dp[i] = (single-digit s[i-1] in 1..=9 ? dp[i-1] : 0)`
+//!         `+ (two-digit  s[i-2..i] in 10..=26 ? dp[i-2] : 0)`.
+//!
+//! Runs in O(n) time and O(1) auxiliary space (rolling window).
+//!
+//! # Panics
+//! Panics if `s` contains a non-ASCII-digit byte. Callers must validate
+//! their input; only `'0'..='9'` characters are accepted.
+
+/// Returns the number of distinct decodings of the digit string `s`.
+///
+/// # Panics
+/// Panics if `s` contains any character outside `'0'..='9'`.
+pub fn num_decodings(s: &str) -> u64 {
+    let bytes = s.as_bytes();
+    for &b in bytes {
+        assert!(
+            b.is_ascii_digit(),
+            "num_decodings: non-digit input byte {b:#x}"
+        );
+    }
+    let n = bytes.len();
+    if n == 0 {
+        return 1;
+    }
+    if bytes[0] == b'0' {
+        return 0;
+    }
+
+    // Rolling window: prev2 = dp[i-2], prev1 = dp[i-1].
+    let mut prev2: u64 = 1; // dp[0]
+    let mut prev1: u64 = 1; // dp[1] (since s[0] != '0')
+    for i in 2..=n {
+        let mut cur: u64 = 0;
+        let one = bytes[i - 1];
+        if one != b'0' {
+            cur += prev1;
+        }
+        let tens = bytes[i - 2] - b'0';
+        let ones = bytes[i - 1] - b'0';
+        let two = (tens as u32) * 10 + ones as u32;
+        if (10..=26).contains(&two) {
+            cur += prev2;
+        }
+        prev2 = prev1;
+        prev1 = cur;
+    }
+    prev1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::num_decodings;
+
+    #[test]
+    fn empty_string_is_one() {
+        assert_eq!(num_decodings(""), 1);
+    }
+
+    #[test]
+    fn twelve_two_ways() {
+        assert_eq!(num_decodings("12"), 2);
+    }
+
+    #[test]
+    fn two_two_six_three_ways() {
+        assert_eq!(num_decodings("226"), 3);
+    }
+
+    #[test]
+    fn leading_zero_is_zero() {
+        assert_eq!(num_decodings("0"), 0);
+    }
+
+    #[test]
+    fn ten_one_way() {
+        assert_eq!(num_decodings("10"), 1);
+    }
+
+    #[test]
+    fn twenty_seven_one_way() {
+        assert_eq!(num_decodings("27"), 1);
+    }
+
+    #[test]
+    fn one_hundred_zero_ways() {
+        assert_eq!(num_decodings("100"), 0);
+    }
+
+    #[test]
+    fn zero_six_zero_ways() {
+        assert_eq!(num_decodings("06"), 0);
+    }
+
+    #[test]
+    fn eleven_one_zero_six_two_ways() {
+        assert_eq!(num_decodings("11106"), 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "non-digit input byte")]
+    fn non_digit_panics() {
+        let _ = num_decodings("12a");
+    }
+}

--- a/src/dynamic_programming/mod.rs
+++ b/src/dynamic_programming/mod.rs
@@ -40,6 +40,7 @@ pub mod divide_and_conquer_optimization;
 
 pub mod buy_sell_stock;
 pub mod convex_hull_trick;
+pub mod decode_ways;
 pub mod digit_dp;
 pub mod game_dag;
 pub mod held_karp;


### PR DESCRIPTION
## Summary
- O(n) DP counting decodings of a digit string under the `1=A..26=Z` mapping, with `dp[0]=1` and any leading `'0'` collapsing to `0`.
- Rolling-window implementation uses O(1) auxiliary space; non-digit input panics with a descriptive message (documented).
- Wired into `src/dynamic_programming/mod.rs`.

## Test plan
- [x] `cargo fmt`
- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test dynamic_programming::decode_ways` (10/10 pass, including "" → 1, "12" → 2, "226" → 3, "0" → 0, "10" → 1, "27" → 1, "100" → 0, "06" → 0, "11106" → 2, and non-digit panic)

Closes #366