### PR TITLE
fix(clippy): satisfy --all-features lints

### DIFF
--- a/src/data_structures/build_tree_pre_in.rs
+++ b/src/data_structures/build_tree_pre_in.rs
@@ -79,19 +79,19 @@ fn build<T: Eq + Hash + Clone>(
 mod tests {
     use super::*;
 
-    fn preorder_collect<T: Clone>(node: &Option<Box<Node<T>>>, out: &mut Vec<T>) {
+    fn preorder_collect<T: Clone>(node: Option<&Node<T>>, out: &mut Vec<T>) {
         if let Some(n) = node {
             out.push(n.value.clone());
-            preorder_collect(&n.left, out);
-            preorder_collect(&n.right, out);
+            preorder_collect(n.left.as_deref(), out);
+            preorder_collect(n.right.as_deref(), out);
         }
     }
 
-    fn inorder_collect<T: Clone>(node: &Option<Box<Node<T>>>, out: &mut Vec<T>) {
+    fn inorder_collect<T: Clone>(node: Option<&Node<T>>, out: &mut Vec<T>) {
         if let Some(n) = node {
-            inorder_collect(&n.left, out);
+            inorder_collect(n.left.as_deref(), out);
             out.push(n.value.clone());
-            inorder_collect(&n.right, out);
+            inorder_collect(n.right.as_deref(), out);
         }
     }
 
@@ -126,17 +126,10 @@ mod tests {
         // Traversal round-trip.
         let mut got_pre = Vec::new();
         let mut got_in = Vec::new();
-        preorder_collect(
-            &Some(Box::new(Node {
-                value: tree.value,
-                left: tree.left,
-                right: tree.right,
-            })),
-            &mut got_pre,
-        );
+        preorder_collect(Some(tree.as_ref()), &mut got_pre);
         // Rebuild for inorder check (previous tree was moved).
         let tree2 = build_tree(&pre, &ino).unwrap();
-        inorder_collect(&Some(tree2), &mut got_in);
+        inorder_collect(Some(tree2.as_ref()), &mut got_in);
         assert_eq!(got_pre, pre);
         assert_eq!(got_in, ino);
     }

--- a/src/greedy/huffman.rs
+++ b/src/greedy/huffman.rs
@@ -112,7 +112,7 @@ pub fn build_codes(freqs: &[(char, u64)]) -> HashMap<char, Vec<bool>> {
     // Sort by (char, freq) so the initial heap-push order is fully
     // deterministic, independent of the input slice's order.
     let mut leaves: Vec<(char, u64)> = totals.into_iter().collect();
-    leaves.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    leaves.sort_unstable_by_key(|&(ch, _)| ch);
 
     let mut heap: BinaryHeap<Reverse<HeapItem>> = BinaryHeap::with_capacity(leaves.len());
     let mut next_seq: u64 = 0;


### PR DESCRIPTION
Resolves two clippy errors that surface only under `cargo clippy --all-targets --all-features -- -D warnings` (the CI configuration):

- `src/greedy/huffman.rs` — switch `sort_unstable_by` to `sort_unstable_by_key` (clippy::unnecessary_sort_by)
- `src/data_structures/build_tree_pre_in.rs` — change test helpers to take `Option<&Node<T>>` instead of `&Option<Box<Node<T>>>` (clippy::ref_option)